### PR TITLE
Make it compile and test ok again

### DIFF
--- a/lib/Slang/Roman.pm6
+++ b/lib/Slang/Roman.pm6
@@ -189,7 +189,7 @@ sub EXPORT(|)
                      :name<&Slang::Roman::to-number>,
                      QAST::SVal.new(:value($number.Str))
                    );
-      $/.'!make'($block);
+      $/.make($block);
       }
     }
 


### PR DESCRIPTION
For some reason, it had a `$/.`!make'($block)` instead of a `$/.make($block)`.  This line appears to have been in there from the initial commit.  So I guess something somewhere changed in the system.  Geoff: any idea why you did the `'!make'` instead of just `make`?